### PR TITLE
Parse and print stacktrace from ECS formatted log

### DIFF
--- a/cmd/kubejob/main.go
+++ b/cmd/kubejob/main.go
@@ -22,7 +22,7 @@ type option struct {
 	File      string `description:"specify yaml or json file for written job definition" short:"f" long:"file"`
 	Image     string `description:"specify container image" short:"i" long:"image"`
 	Verbose   bool   `description:"set log level to verbose" short:"v" long:"verbose"`
-	Logformat string `description:"log format" short:"t" long:"template" default:"{{ .Timestamp }} | {{ .Message }}"`
+	Logformat string `description:"log format" short:"t" long:"template" default:"{{ .Timestamp }} | {{ .Message }}{{ if .StackTrace }}\n{{ end }}{{ .StackTrace }}"`
 }
 
 func getKubeConfig() string {

--- a/job.go
+++ b/job.go
@@ -258,6 +258,7 @@ type ECSFormatLog struct {
 	EventDataset string `json:"event.dataset"`
 	EcsVersion string `json:"ecs.version"`
 	ServiceName string `json:"service.name"`
+	StackTrace string `json:"error.stack_trace"`
 }
 
 func (c *ContainerLog) parseECSFormatLog() (ECSFormatLog, error) {


### PR DESCRIPTION
Verified using: https://github.com/tanishiking/ecs-kubejob-test

### Before
```
2021-11-22T07:39:09.107Z | foo
2021-11-22T07:39:09.129Z | foo
```

### After
```
2021-11-22T07:39:09.107Z | foo
2021-11-22T07:39:09.129Z | foo
java.lang.Exception: foo
        at Hello$.delayedEndpoint$Hello$1(Hello.scala:4)
        at Hello$delayedInit$body.apply(Hello.scala:3)
        at scala.Function0.apply$mcV$sp(Function0.scala:39)
        at scala.Function0.apply$mcV$sp$(Function0.scala:39)
        at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
        at scala.App.$anonfun$main$1(App.scala:76)
        at scala.App.$anonfun$main$1$adapted(App.scala:76)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
        at scala.App.main(App.scala:76)
        at scala.App.main$(App.scala:74)
        at Hello$.main(Hello.scala:3)
        at Hello.main(Hello.scala)
```